### PR TITLE
Add ERB to pry mappings

### DIFF
--- a/plugin/pry.vim
+++ b/plugin/pry.vim
@@ -9,6 +9,7 @@ let g:pry_map = {
       \ 'javascript' : 'debugger',
       \ 'javascript.jsx' : 'debugger',
       \ 'elixir' : 'require IEx; IEx.pry',
+      \ 'eruby' : "<% require 'pry'; binding.pry %>",
       \}
 
 function! pry#insert()


### PR DESCRIPTION
This PR:
  - Adds a definition for eruby (`.erb`) files.

Why?
  - So it all works!