### PR TITLE
Update pry.vim to support typescript files

### DIFF
--- a/plugin/pry.vim
+++ b/plugin/pry.vim
@@ -10,6 +10,7 @@ let g:pry_map = {
       \ 'javascript.jsx' : 'debugger',
       \ 'elixir' : 'require IEx; IEx.pry',
       \ 'eruby' : "<% require 'pry'; binding.pry %>",
+      \ 'typescript' : 'debugger',
       \}
 
 function! pry#insert()


### PR DESCRIPTION
This PR:
  - Adds a key value for typescript files

Why?
  - This didn't exist.